### PR TITLE
Issue 18: Correctly implement a wake lock for an alarm manager.

### DIFF
--- a/tcn-client-android/src/main/AndroidManifest.xml
+++ b/tcn-client-android/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <uses-feature
         android:name="android.hardware.bluetooth_le"

--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/TcnConstants.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/TcnConstants.kt
@@ -35,4 +35,7 @@ object TcnConstants {
 
     private const val H_TCK_DOMAIN_SEPARATOR_STRING = "H_TCK"
     val H_TCK_DOMAIN_SEPARATOR = H_TCK_DOMAIN_SEPARATOR_STRING.toByteArray(Charsets.UTF_8)
+
+    const val WAKELOCK_TAG = "org:tcn-coalition:alarm-receiver"
+    const val WAKELOCK_DURATION = 10000 // This should be set to the longest amount of time it would take to do a scan
 }

--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/receiver/ChangeOwnTcnReceiver.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/receiver/ChangeOwnTcnReceiver.kt
@@ -4,11 +4,22 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.os.PowerManager
 import org.tcncoalition.tcnclient.TcnClient
+import org.tcncoalition.tcnclient.TcnConstants.WAKELOCK_DURATION
+import org.tcncoalition.tcnclient.TcnConstants.WAKELOCK_TAG
 
 class ChangeOwnTcnReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
-        TcnClient.tcnManager?.changeOwnTcn()
+        context?.let {
+            val pm = it.getSystemService(Context.POWER_SERVICE) as PowerManager
+            val wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, WAKELOCK_TAG)
+            wl.acquire(WAKELOCK_DURATION.toLong())
+
+            TcnClient.tcnManager?.changeOwnTcn()
+
+            wl.release()
+        }
     }
 
     companion object {


### PR DESCRIPTION
This will keep your handset from Dozing mid scan.  With what you have now you can get put to sleep mid way through and depending on the version of the OS you might not even wake up all the way.  Not good.