### PR TITLE
Advertise the ios tcn at least once

### DIFF
--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
@@ -1,21 +1,7 @@
 package org.tcncoalition.tcnclient.bluetooth
 
-import android.bluetooth.BluetoothDevice
-import android.bluetooth.BluetoothGatt
-import android.bluetooth.BluetoothGattCharacteristic
-import android.bluetooth.BluetoothGattServer
-import android.bluetooth.BluetoothGattServerCallback
-import android.bluetooth.BluetoothGattService
-import android.bluetooth.BluetoothManager
-import android.bluetooth.le.AdvertiseCallback
-import android.bluetooth.le.AdvertiseData
-import android.bluetooth.le.AdvertiseSettings
-import android.bluetooth.le.BluetoothLeAdvertiser
-import android.bluetooth.le.BluetoothLeScanner
-import android.bluetooth.le.ScanCallback
-import android.bluetooth.le.ScanFilter
-import android.bluetooth.le.ScanResult
-import android.bluetooth.le.ScanSettings
+import android.bluetooth.*
+import android.bluetooth.le.*
 import android.content.Context
 import android.os.Build
 import android.os.Handler
@@ -23,12 +9,38 @@ import android.os.ParcelUuid
 import android.util.Base64
 import android.util.Log
 import org.tcncoalition.tcnclient.TcnConstants
-import java.util.Timer
-import java.util.TimerTask
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import kotlin.collections.ArrayList
+import kotlin.collections.set
+
+/**
+ * Entry object of the advertising queue
+ */
+data class AdvertisingEntry(
+    val tcn: ByteArray,
+    var hasAdvertised: Boolean
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AdvertisingEntry
+
+        if (!tcn.contentEquals(other.tcn)) return false
+        if (hasAdvertised != other.hasAdvertised) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = tcn.contentHashCode()
+        result = 31 * result + hasAdvertised.hashCode()
+        return result
+    }
+}
 
 class TcnBluetoothManager(
     private val context: Context,
@@ -41,7 +53,7 @@ class TcnBluetoothManager(
 
     private var isStarted: Boolean = false
     private var generatedTcn = ByteArray(0)
-    private var tcnAdvertisingQueue = ArrayList<ByteArray>()
+    private var tcnAdvertisingQueue = ArrayList<AdvertisingEntry>()
     private var inRangeBleAddressToTcnMap = mutableMapOf<String, ByteArray>()
     private var estimatedDistanceToRemoteDeviceAddressMap = mutableMapOf<String, Double>()
 
@@ -110,7 +122,7 @@ class TcnBluetoothManager(
         executor?.execute {
             Log.i(TAG, "Changing own TCN ...")
             // Remove current TCN from the advertising queue.
-            dequeueFromAdvertising(generatedTcn)
+            dequeueFromAdvertising(generatedTcn, true)
             val tcn = tcnCallback.generateTcn()
             Log.i(TAG, "Did generate TCN=${Base64.encodeToString(tcn, Base64.NO_WRAP)}")
             generatedTcn = tcn
@@ -122,18 +134,32 @@ class TcnBluetoothManager(
         }
     }
 
-    private fun dequeueFromAdvertising(tcn: ByteArray?) {
-        tcn ?: return
-        tcnAdvertisingQueue.remove(tcn)
-        Log.i(TAG, "Dequeued TCN=${Base64.encodeToString(tcn, Base64.NO_WRAP)} from advertising")
+    /**
+     * Remove TCN from advertising queue
+     * @param forceRemove if true, remove the entry even if it has not been advertised
+     * @return true if successfully removed
+     */
+    private fun dequeueFromAdvertising(tcn: ByteArray?, forceRemove: Boolean = false): Boolean {
+        val index =
+            tcnAdvertisingQueue.indexOfFirst { (forceRemove || it.hasAdvertised) && it.tcn === tcn }    // remove TCN from the queue only if it has been advertised
+        if (index >= 0) {
+            tcnAdvertisingQueue.removeAt(index)
+            Log.i(TAG, "Dequeued TCN=${Base64.encodeToString(tcn, Base64.NO_WRAP)} from advertising")
+            return true
+        } else {
+            return false
+        }
     }
 
-    private fun enqueueForAdvertising(tcn: ByteArray?, atHead: Boolean = false) {
+    private fun enqueueForAdvertising(
+        tcn: ByteArray?,
+        atHead: Boolean = false
+    ) {
         tcn ?: return
         if (atHead) {
-            tcnAdvertisingQueue.add(0, tcn)
+            tcnAdvertisingQueue.add(0, AdvertisingEntry(tcn, false))
         } else {
-            tcnAdvertisingQueue.add(tcn)
+            tcnAdvertisingQueue.add(AdvertisingEntry(tcn, false))
         }
         Log.i(TAG, "Enqueued TCN=${Base64.encodeToString(tcn, Base64.NO_WRAP)} for advertising")
     }
@@ -222,7 +248,7 @@ class TcnBluetoothManager(
                 val scanRecord = it.scanRecord ?: return@for_each
 
                 val tcnServiceData = scanRecord.serviceData[
-                    ParcelUuid(TcnConstants.UUID_SERVICE)]
+                        ParcelUuid(TcnConstants.UUID_SERVICE)]
 
                 val hintIsAndroid = (tcnServiceData != null)
 
@@ -266,8 +292,9 @@ class TcnBluetoothManager(
             }
             addressesToRemove.forEach {
                 val tcn = inRangeBleAddressToTcnMap[it]
-                dequeueFromAdvertising(tcn)
-                inRangeBleAddressToTcnMap.remove(it)
+                if (dequeueFromAdvertising(tcn)) {
+                    inRangeBleAddressToTcnMap.remove(it)
+                }
             }
 
             // Notify the API user that TCNs which are left in the list are still in range and
@@ -305,16 +332,18 @@ class TcnBluetoothManager(
                     // devices writing a new TCN to us whenever we rotate the TCN (every 20 sec).
                     // iOS devices use the last 4 bytes to identify the Android devices and write
                     // only once a TCN to them.
-                    tcnAdvertisingQueue.first() + generatedTcn.sliceArray(0..3)
+                    tcnAdvertisingQueue.first().tcn + generatedTcn.sliceArray(0..3)
                 )
                 .build()
+
+            tcnAdvertisingQueue.first().hasAdvertised = true
 
             advertiser.startAdvertising(settings, data, advertisingCallback)
             Log.i(
                 TAG, "Started advertising TCN=${Base64.encodeToString(
-                    tcnAdvertisingQueue.first(),
+                    tcnAdvertisingQueue.first().tcn,
                     Base64.NO_WRAP
-                )} isOwn=${tcnAdvertisingQueue.first().contentEquals(generatedTcn)}"
+                )} isOwn=${tcnAdvertisingQueue.first().tcn.contentEquals(generatedTcn)}"
             )
         } catch (exception: Exception) {
             Log.e(TAG, "Start advertising failed: $exception")
@@ -367,7 +396,7 @@ class TcnBluetoothManager(
                             // each other while in the background.
                             if (device != null) {
                                 inRangeBleAddressToTcnMap[device.address] = value
-                                enqueueForAdvertising(value)
+                                enqueueForAdvertising(value, false)
                             }
                         } else {
                             result = BluetoothGatt.GATT_FAILURE

--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
@@ -1,7 +1,21 @@
 package org.tcncoalition.tcnclient.bluetooth
 
-import android.bluetooth.*
-import android.bluetooth.le.*
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattServer
+import android.bluetooth.BluetoothGattServerCallback
+import android.bluetooth.BluetoothGattService
+import android.bluetooth.BluetoothManager
+import android.bluetooth.le.AdvertiseCallback
+import android.bluetooth.le.AdvertiseData
+import android.bluetooth.le.AdvertiseSettings
+import android.bluetooth.le.BluetoothLeAdvertiser
+import android.bluetooth.le.BluetoothLeScanner
+import android.bluetooth.le.ScanCallback
+import android.bluetooth.le.ScanFilter
+import android.bluetooth.le.ScanResult
+import android.bluetooth.le.ScanSettings
 import android.content.Context
 import android.os.Build
 import android.os.Handler
@@ -9,12 +23,12 @@ import android.os.ParcelUuid
 import android.util.Base64
 import android.util.Log
 import org.tcncoalition.tcnclient.TcnConstants
-import java.util.*
+import java.util.Timer
+import java.util.TimerTask
+import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import kotlin.collections.ArrayList
-import kotlin.collections.set
 
 /**
  * Entry object of the advertising queue

--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/bluetooth/TcnBluetoothManager.kt
@@ -409,6 +409,9 @@ class TcnBluetoothManager(
                             // We act as a bridge and advertise these TCNs so iOS apps can discover
                             // each other while in the background.
                             if (device != null) {
+                                if (inRangeBleAddressToTcnMap.containsKey(device.address)) {
+                                    dequeueFromAdvertising(inRangeBleAddressToTcnMap[device.address], true)
+                                }
                                 inRangeBleAddressToTcnMap[device.address] = value
                                 enqueueForAdvertising(value, false)
                             }

--- a/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/crypto/Report.kt
+++ b/tcn-client-android/src/main/java/org/tcncoalition/tcnclient/crypto/Report.kt
@@ -14,6 +14,11 @@ enum class MemoType(internal val t: Byte) {
     /** The CovidWatch test data format, version 1 (TBD) */
     CovidWatchV1(1),
 
+    /**
+     * The HutchTrace app data format
+     */
+    HutchTraceV1(3),
+
     /** Reserved for future use. */
     Reserved(-1);
 
@@ -24,6 +29,7 @@ enum class MemoType(internal val t: Byte) {
             return when (t.toInt()) {
                 0 -> CoEpiV1
                 1 -> CovidWatchV1
+                3 -> HutchTraceV1
                 else -> throw UnknownMemoType(t)
             }
         }


### PR DESCRIPTION
When we test android bridge use case: one android phone and two iphones (with the apps running in background). 

Every 15min, when the android tcn is changed, the android app detects the tcns from both iPhones and then enqueue them for advertising. Most times, the enqueued ios tcns are dequeued immediately because the scanner finds nothing. As a result, the two iphones are unable to exchange the tcns when they are in background. 

This PR proposed a workaround to ensure each ios tcn is broadcasted at least once. 
Please let us know if you have a better solution for this usecase. 

Thanks. 
